### PR TITLE
use `find-root` for reliable package.json lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var path = require('path'),
+var findRoot = require('find-root'),
+    path = require('path'),
     through2 = require('through2');
 
 function versionify(options) {
@@ -7,7 +8,8 @@ function versionify(options) {
 
     var filter = options.filter,
         placeholder = options.placeholder || '__VERSION__',
-        version = options.version || require(path.resolve('package.json')).version,
+        version = options.version ||
+          require(path.join(findRoot(process.cwd()), 'package.json')).version,
         re = new RegExp(placeholder, 'g');
 
     return function(file, opts) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "find-root": "^0.1.1",
     "through2": "0.6.3"
   }
 }


### PR DESCRIPTION
[`find-root`](https://www.npmjs.com/package/find-root) reliably finds the closest `package.json`.

This PR fixes #1.
