### PR TITLE
Accept parameters when used as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,12 @@ From command line:
 
 From Node.js:
 
-    var versionify = require('browserify-versionify');
-
-    browserify().transform(versionify);
+    browserify().transform('browserify-versionify');
 
     // Configure (default values shown)
-    browserify().transform(versionify.configure({
+    browserify().transform('browserify-versionify', {
         placeholder: '__VERSION__',
         version: pkg.version
-    }));
+    });
 
 You can also provide a `filter` property to whitelist files to apply the transform to (e.g. `filter: /\.js$/`).

--- a/index.js
+++ b/index.js
@@ -2,24 +2,27 @@ var findRoot = require('find-root'),
     path = require('path'),
     through2 = require('through2');
 
-function versionify(options) {
+function versionify(file, options) {
 
     options = options || {};
-
     var filter = options.filter,
         placeholder = options.placeholder || '__VERSION__',
         version = options.version ||
             require(path.join(findRoot(process.cwd()), 'package.json')).version,
         re = new RegExp(placeholder, 'g');
 
-    return function(file, opts) {
-        if (filter && !filter.test(file)) return through2();
-        return through2({objectMode: true}, function(chunk, encoding, callback) {
-            return callback(null, chunk.toString().replace(re, version))
-        });
+    if (filter && !filter.test(file)) {
+        return through2();
     }
+    return through2({objectMode: true}, function(chunk, encoding, callback) {
+        return callback(null, chunk.toString().replace(re, version));
+    });
 }
 
-exports = module.exports = versionify();
+versionify.configure = function(options) {
+    return function(file) {
+        return versionify(file, options);
+    };
+};
 
-exports.configure = versionify;
+module.exports = versionify;


### PR DESCRIPTION
According to the browserify docs, it should be possible to use a transform like this:

```js
var options = {};

var bundle = browserify();
b.transform('transform', options);
```

However, versionify discards the options when used this way, because it never uses the "opts" variable it receives.
This patch fixes that. The .configure() method is now redundant, but I modified that too, to keep BC.
